### PR TITLE
Add support for default parameter groups

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -26,7 +26,7 @@
   version = "v1.5"
 
 [[projects]]
-  digest = "1:7d2caf3cc11843a98100f4e278053d7e47d375cc4ca89fd310f7e759b86555a4"
+  digest = "1:dfce6299035dce6218178c4fc17f3d07c4393c2bdb49c6b556336bebba0aabef"
   name = "github.com/aws/aws-sdk-go"
   packages = [
     "aws",
@@ -38,6 +38,7 @@
     "aws/credentials",
     "aws/credentials/ec2rolecreds",
     "aws/credentials/endpointcreds",
+    "aws/credentials/processcreds",
     "aws/credentials/stscreds",
     "aws/csm",
     "aws/defaults",
@@ -61,8 +62,8 @@
     "service/sts",
   ]
   pruneopts = "UT"
-  revision = "936c5266940725e6a728ea4b7241ede3f1616096"
-  version = "v1.15.82"
+  revision = "81f3829f5a9d041041bdf56e55926691309d7699"
+  version = "v1.16.26"
 
 [[projects]]
   digest = "1:705c40022f5c03bf96ffeb6477858d88565064485a513abcd0f11a0911546cb6"
@@ -129,7 +130,7 @@
   version = "v1.4.1"
 
 [[projects]]
-  digest = "1:db70b5a027ff61adbeaaa91408bf99fda07b14ce7c919a963b9512112503dd4f"
+  digest = "1:5447229ef5527bc9b10e94f037d6bf26b1d172a4b624eb35a65076b5cf554441"
   name = "github.com/gobuffalo/buffalo"
   packages = [
     ".",
@@ -139,68 +140,68 @@
     "worker",
   ]
   pruneopts = "T"
-  revision = "e362599b8489bd6e0b62e357bdeb044498c04143"
-  version = "v0.13.7"
+  revision = "3efafb960e472de753a1f8a9c6cd5f4a3719b784"
+  version = "v0.13.13"
 
 [[projects]]
-  digest = "1:783552a64272c990bae4c47edcd023d18a3a26a8d931c237aefc21969d0cdcbf"
+  digest = "1:3e067df3c1fc8619e2a563b49c57acbe72d4082e43191dd6b48ceac8c675487e"
   name = "github.com/gobuffalo/buffalo-plugins"
   packages = [
     "plugins",
     "plugins/plugdeps",
   ]
   pruneopts = "UT"
-  revision = "b995da984b81029e81dd942087089f3b0a56c7c2"
-  version = "v1.7.2"
+  revision = "f34e38fbc353e263d53fec0fd045bd466d3ea315"
+  version = "v1.13.0"
 
 [[projects]]
-  digest = "1:ba4a13c1846fc9df263e43e61854e2ce530eadfdc10a7ea394cc3b76b42ddaed"
+  digest = "1:4868df29afe0468bd98f663aff34f486b2e92db41f25747d8e6855c9cd91808b"
   name = "github.com/gobuffalo/envy"
   packages = ["."]
   pruneopts = "UT"
-  revision = "b29bf6b8134f3398b9333ba1893c58620152edb0"
-  version = "v1.6.9"
+  revision = "f3b98d4da2fa434517f47f615e217fa72ff2c51e"
+  version = "v1.6.12"
 
 [[projects]]
-  digest = "1:162c24dc1a7b2a487e5bfe99be2e7f66dfa2ae5605235504dd6962df00e3e9fd"
+  digest = "1:2637749e262a2b880b925752dc7416992c33baede48df061f3aaed5efe6d2974"
   name = "github.com/gobuffalo/events"
   packages = ["."]
   pruneopts = "UT"
-  revision = "737cbff69244d23760f88158381db90594b0c33c"
-  version = "v1.1.8"
+  revision = "7405490b2bb796f2d6aaea94f4c8692e67aa7086"
+  version = "v1.2.0"
 
 [[projects]]
-  digest = "1:6dfda07e02354fa596ae85622b214e52bcd36cd0ff7e44343aaa2ea31d280f93"
+  digest = "1:a63edf6a4aef1156d3553a5f4869a85c13c02a3ce7be8c0e94704877ef847442"
   name = "github.com/gobuffalo/fizz"
   packages = [
     ".",
     "translators",
   ]
   pruneopts = "UT"
-  revision = "8ac54629c9b8f484bc21be7a8fd327f63d1d814b"
-  version = "v1.1.3"
+  revision = "e70bf7d38ac1298601cccc46567ef323a12f8e51"
+  version = "v1.5.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:8d77dba62e39e710f9e71f6c6405c45000b17011291339360b7411fa92e43390"
+  digest = "1:50696b7f377225a46edf39edf659fd1757b5fcfa17fbadf2ab402b8dceca40b1"
   name = "github.com/gobuffalo/flect"
   packages = [
     ".",
     "name",
   ]
   pruneopts = "UT"
-  revision = "47375f6d832895843594c60e150fc0a2d2ef87df"
+  revision = "a62e61d96794ba2b40ecfe3d314242e14e18fdd6"
 
 [[projects]]
   branch = "master"
-  digest = "1:56a0a430f684fb47a45af584aadb29932607d27314b0a0476f68dfa536f158c0"
+  digest = "1:be759141c726f1997b3202827418b47c0df6d5460074c679097a7f4038b3e14f"
   name = "github.com/gobuffalo/genny"
   packages = [
     ".",
     "movinglater/gotools/gomods",
   ]
   pruneopts = "UT"
-  revision = "e8ff4adce8bbd7b8c776e2708ef620036369632e"
+  revision = "008a76242145c9fca08b9047da7da6108292c569"
 
 [[projects]]
   digest = "1:114fbde5ab0239bddb4e8733d3174f8f4008ff84d7161c549e501a4339bdc75c"
@@ -218,20 +219,20 @@
   version = "v1.0.7"
 
 [[projects]]
-  digest = "1:c7ee8734b6c0c54de87f67ba6f7250fc7d449961fe2ecc3831b10957aafa9228"
+  digest = "1:61fca0440c5723116c169bcc1543e413d640d04ba1f6bbee566e1908ad9e688c"
   name = "github.com/gobuffalo/httptest"
   packages = ["."]
   pruneopts = "UT"
-  revision = "dd4e2beb3e1fb96c5f887b39020e194ba3099b94"
-  version = "v1.0.5"
+  revision = "294cbc067e1fc9940322f300d7124c03216df581"
+  version = "v1.1.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:10e6311b9b5d075d877163ae6f92b1571cd673de0e7d7d807a56c29e2858e6b1"
+  digest = "1:e8cb200d6a09e43a021bf746a83ebf8c82b8e8a943c211cdcddc680f2d9e6cfb"
   name = "github.com/gobuffalo/logger"
   packages = ["."]
   pruneopts = "UT"
-  revision = "8e9b89b7c2640424fb582d00d389a4df9ea83ab8"
+  revision = "5b956e21995cbed3ab29e4901f9e746a6a1d53bb"
 
 [[projects]]
   digest = "1:429c929bb5abee25889f9c9783f046a9d8b97d16e1f5734187defe2bca68ae67"
@@ -251,46 +252,46 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:304e59991ca9877a3218da7666add20bdc888ec9860c82e04dc7a844c2b91400"
+  digest = "1:445896036297a8b0ee8f38da6946f3e0d7c520c7af4c29335b53e08049a7091b"
   name = "github.com/gobuffalo/meta"
   packages = ["."]
   pruneopts = "UT"
-  revision = "8850e47774f5faf68478418d9219e2aa9e3cd269"
+  revision = "c8fb6f4eb5a9cb0fa2e37ef6e42c2f71e19a1ca8"
 
 [[projects]]
   branch = "master"
-  digest = "1:09fa6d091e821158250363f83fc8efc38f3ff8f850df54578e65a7eb132649b1"
+  digest = "1:c727005750f7000b579bd2d65a6ebdaef9fd51a2319f990952c1c253309b6d97"
   name = "github.com/gobuffalo/mw-csrf"
   packages = ["."]
   pruneopts = "UT"
-  revision = "446ff26e108b9a8933dfc854d37a68d5adf2c226"
+  revision = "25460a05551774654d807c1586d9bac3bb2a26c9"
 
 [[projects]]
   branch = "master"
-  digest = "1:29b501ddc9a2f895cbd1ed4670a0322ecbf677529d43fdca7de9b73a78461096"
+  digest = "1:ade50751196b07ad42304ab26c9463ebfb62ed2b24b942129a7482dfd5ef2e8d"
   name = "github.com/gobuffalo/mw-paramlogger"
   packages = ["."]
   pruneopts = "UT"
-  revision = "d6ee392ec72e2863654657a8449a58e47420e617"
+  revision = "395da19985257a56c0e7a4da1afbaff0b77e1b46"
 
 [[projects]]
   branch = "master"
-  digest = "1:a5b87cc8e6e9d842be6bcf371991b47ca2a15ca2b763f620518ab37d841a78c6"
+  digest = "1:3617620c7cbc54dc84ab1f674ca021c1a9f49eeaa98ff81ceb202a626c7b9c66"
   name = "github.com/gobuffalo/packd"
   packages = ["."]
   pruneopts = "UT"
-  revision = "311c6248e5fbdcd13b3ce364f00073506d8154e6"
+  revision = "eca3b8fd66872a76119b189bbe0f58f776a2a39f"
 
 [[projects]]
-  digest = "1:05f90e1f4ad8f5ba56e4367b70183410fb6584390e06ed7dc79be3500ca54600"
+  digest = "1:bdff32be91d09c91f3348b0e038baad6c5bafe1692b940055ee820828d1c4b1b"
   name = "github.com/gobuffalo/packr"
   packages = ["."]
   pruneopts = "UT"
-  revision = "ba3c3ae9169fdc7b283f00a4b4c39346e444871c"
-  version = "v1.21.5"
+  revision = "2745c044a8699bced928776bfa1fc98e3148ec7e"
+  version = "v2.0.0"
 
 [[projects]]
-  digest = "1:07e10ef52f5f704dfd64c7fa5760cff981be537008df04b10f7c7c70ed34a7f5"
+  digest = "1:5351c0e4a0c0f48f30a332b65962ac8873cd0a000068276609e35b54725efaab"
   name = "github.com/gobuffalo/plush"
   packages = [
     ".",
@@ -300,11 +301,11 @@
     "token",
   ]
   pruneopts = "UT"
-  revision = "57b7dec2591b31bb8ff31793019a0904a20b0d98"
-  version = "v3.7.22"
+  revision = "f69cf36b7832a533698bcb7a9dc7954ed1588671"
+  version = "v3.7.33"
 
 [[projects]]
-  digest = "1:13fd2e5780900e87cf2c952a3adf1c51b5dba96e9b2de1a19c83e65ac6b92eca"
+  digest = "1:4b2353d4245e0d96205f26fa4437f22299a2fba7af09e514398da4e8078f1664"
   name = "github.com/gobuffalo/pop"
   packages = [
     ".",
@@ -315,8 +316,8 @@
     "nulls",
   ]
   pruneopts = "T"
-  revision = "70da24950427447ab44569b9b5ecd5951144f8ab"
-  version = "v4.9.2"
+  revision = "f2c9532e46892d9c943bf85ec4f86bbab1abfbda"
+  version = "v4.9.6"
 
 [[projects]]
   digest = "1:de29dc9e7c845c2538f5a3e7609e611bfca933119512058fc90d0c1b47031830"
@@ -338,7 +339,7 @@
   revision = "558ac7de985fc4f4057bff27c7bdf99e92fe0750"
 
 [[projects]]
-  digest = "1:67caa8474de61d17bd909ffac7818fa7abd5a4e5f8af05bc8edd4cfdda18ddff"
+  digest = "1:dc696015082adab90eb8fceb3f2cd6d816a68f6ee081d66d2d9f1c23c8e08a04"
   name = "github.com/gobuffalo/tags"
   packages = [
     ".",
@@ -346,8 +347,8 @@
     "form/bootstrap",
   ]
   pruneopts = "UT"
-  revision = "da5de2a6b4fdd40153789f7efff1330616e28de7"
-  version = "v2.0.11"
+  revision = "5bface973eaf8938807a6d0c075c415911f45b48"
+  version = "v2.0.15"
 
 [[projects]]
   digest = "1:4b6a43ba3296f26ea01ae125e50951f141c215dd18b5b91e9f397117b2951eb1"
@@ -382,12 +383,12 @@
   revision = "14085ca3e1a995a72ac03700ee3e6b56706bda8e"
 
 [[projects]]
-  digest = "1:c594a691090b434d55c67f6cc8e326ef5ba49452abc059821bd5d4fd4cdef08c"
+  digest = "1:bed9d72d596f94e65fff37f4d6c01398074a6bb1c3f3ceff963516bd01db6ff5"
   name = "github.com/gofrs/uuid"
   packages = ["."]
   pruneopts = "UT"
-  revision = "7077aa61129615a0d7f45c49101cd011ab221c27"
-  version = "v3.1.2"
+  revision = "6b08a5c5172ba18946672b49749cde22873dd7c2"
+  version = "v3.2.0"
 
 [[projects]]
   digest = "1:c79fb010be38a59d657c48c6ba1d003a8aa651fa56b579d959d74573b7dff8e1"
@@ -398,12 +399,12 @@
   version = "v1.1.1"
 
 [[projects]]
-  digest = "1:e73f5b0152105f18bc131fba127d9949305c8693f8a762588a82a48f61756f5f"
+  digest = "1:ca59b1175189b3f0e9f1793d2c350114be36eaabbe5b9f554b35edee1de50aea"
   name = "github.com/gorilla/mux"
   packages = ["."]
   pruneopts = "UT"
-  revision = "e3702bed27f0d39777b0b37b664b6280e8ef8fbf"
-  version = "v1.6.2"
+  revision = "a7962380ca08b5a188038c69871b8d3fbdf31e89"
+  version = "v1.7.0"
 
 [[projects]]
   digest = "1:e72d1ebb8d395cf9f346fd9cbc652e5ae222dd85e0ac842dc57f175abed6d195"
@@ -430,7 +431,7 @@
   version = "v1.0"
 
 [[projects]]
-  digest = "1:8dfbec76b4834d96c37ba4c4969fc47c9a15e67c5a7eecfa031fbe67dab50429"
+  digest = "1:6a5edb6e9ad91f22d33e01739bbabea324fed674c40bc4f7d60adb48235e8b48"
   name = "github.com/jackc/pgx"
   packages = [
     ".",
@@ -441,15 +442,15 @@
     "pgtype",
   ]
   pruneopts = "UT"
-  revision = "89f1e6ac7276b61d885db5e5aed6fcbedd1c7e31"
-  version = "v3.2.0"
+  revision = "c59c9cac59ab95eceb0c12ff338923c62f411ea2"
+  version = "v3.3.0"
 
 [[projects]]
-  digest = "1:e22af8c7518e1eab6f2eab2b7d7558927f816262586cd6ed9f349c97a6c285c4"
+  digest = "1:bb81097a5b62634f3e9fec1014657855610c82d19b9a40c17612e32651e35dca"
   name = "github.com/jmespath/go-jmespath"
   packages = ["."]
   pruneopts = "UT"
-  revision = "0b12d6b5"
+  revision = "c2b33e84"
 
 [[projects]]
   digest = "1:6c41d4f998a03b6604227ccad36edaed6126c397e5d78709ef4814a1145a6757"
@@ -471,12 +472,12 @@
   version = "v1.3.0"
 
 [[projects]]
-  digest = "1:d395d2621c61bdbcaf62fb749d90ec55a51d112329e653aeca87fbd1075723aa"
+  digest = "1:733d809a22d48576a16f7aec67bb60ea5de3eb220e95fcee8098b296b7c0c9e8"
   name = "github.com/karrick/godirwalk"
   packages = ["."]
   pruneopts = "UT"
-  revision = "2de2192f9e35ce981c152a873ed943b93b79ced4"
-  version = "v1.7.5"
+  revision = "dfb93c3b8093779973bb5ace7d7f7666b99d4298"
+  version = "v1.7.8"
 
 [[projects]]
   branch = "master"
@@ -506,15 +507,15 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:415c4eb126a312ba2baa4654a02f5dde420403d66e772ad0a9554639f40eb0d1"
+  digest = "1:66efd51370fc704fc2a331ea66905526a8aed4153005263b2667d0b6a8f56918"
   name = "github.com/markbates/going"
   packages = [
     "defaults",
     "randx",
   ]
   pruneopts = "UT"
-  revision = "e6789dc391e3308d92d2f9131990b7426e5e3066"
-  version = "v1.0.2"
+  revision = "7745e382f2e927b7ad1bc04524fa32217acaeb15"
+  version = "v1.0.3"
 
 [[projects]]
   digest = "1:fecb0ae22407090e8cceb1b108d1f44576420f8450213c0f18416745d80504eb"
@@ -542,22 +543,22 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:598aa4555d1ea05a7b949e31e7db0e7b2df21f8772c53cc42f6543dc6bf9a35a"
+  digest = "1:6e2ed1bdbf1d14b4d0be58bcd3f1c3000c1e226964354457b8e6ca69e83a1cbb"
   name = "github.com/markbates/oncer"
   packages = ["."]
   pruneopts = "UT"
-  revision = "05fccaae8fc423476d98fd4c3e4699ba0fbbde48"
+  revision = "bf2de49a0be218916e69a11d22866e6cd0a560f2"
 
 [[projects]]
-  digest = "1:3a234299235b17ad5ad2227707e8029a8ae249037316ee37f1b769f507f8839a"
+  digest = "1:d01b673d3f1703550f181bc1a18bcfeffdf7a4d98a94f9c0a972a3cc8f04d24a"
   name = "github.com/markbates/refresh"
   packages = [
     "refresh",
     "refresh/web",
   ]
   pruneopts = "UT"
-  revision = "4a017449d85be7e77ec41bb7327e10151ffba6e0"
-  version = "v1.4.11"
+  revision = "16d8fc0043cfb5ce88c7960875f8473833e62a12"
+  version = "v1.6.0"
 
 [[projects]]
   digest = "1:28687e854cec240942c103259668b132a8450b05a6cc677eea2282b26ae29310"
@@ -600,20 +601,20 @@
   version = "v1.10.0"
 
 [[projects]]
-  digest = "1:1fc201f179a7d45f944655de3cdbfb0a8a226fd525569454e31ca87f9e4bb677"
+  digest = "1:6ff1026b8d873d074ddec82ad60bb0eb537dc013f456ef26b63d30beba2f99e7"
   name = "github.com/microcosm-cc/bluemonday"
   packages = ["."]
   pruneopts = "UT"
-  revision = "82c7118e8ccf7403d4860175d97bb635e8e28239"
-  version = "v1.0.1"
+  revision = "506f3da9b7c86d737e91f16b7431df8635871552"
+  version = "v1.0.2"
 
 [[projects]]
-  digest = "1:78bbb1ba5b7c3f2ed0ea1eab57bdd3859aec7e177811563edc41198a760b06af"
+  digest = "1:5d231480e1c64a726869bc4142d270184c419749d34f167646baa21008eb0a79"
   name = "github.com/mitchellh/go-homedir"
   packages = ["."]
   pruneopts = "UT"
-  revision = "ae18d6b8b3205b561c79e8e5f69bff09736185f4"
-  version = "v1.0.0"
+  revision = "af06845cf3004701891bf4fdb884bfe4920b3727"
+  version = "v1.1.0"
 
 [[projects]]
   digest = "1:9f6f7ba2d9477766a32520ac15339c00d5c1baebb84091d43c9f0d68c04b78bb"
@@ -624,12 +625,12 @@
   version = "v3.1"
 
 [[projects]]
-  digest = "1:40e195917a951a8bf867cd05de2a46aaf1806c50cf92eebf4c16f78cd196f747"
+  digest = "1:cf31692c14422fa27c83a05292eb5cbe0fb2775972e8f1f8446a71549bd8980b"
   name = "github.com/pkg/errors"
   packages = ["."]
   pruneopts = "UT"
-  revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
-  version = "v0.8.0"
+  revision = "ba968bfe8b2f7e042a574c888954fccecfa385b4"
+  version = "v0.8.1"
 
 [[projects]]
   digest = "1:0028cb19b2e4c3112225cd871870f2d9cf49b9b4276531f03438a88e94be86fe"
@@ -638,6 +639,18 @@
   pruneopts = "UT"
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
+
+[[projects]]
+  digest = "1:e09ada96a5a41deda4748b1659cc8953961799e798aea557257b56baee4ecaf3"
+  name = "github.com/rogpeppe/go-internal"
+  packages = [
+    "modfile",
+    "module",
+    "semver",
+  ]
+  pruneopts = "UT"
+  revision = "68d1cb014f030acd0f10ac553801e43c0e5da629"
+  version = "v1.1.0"
 
 [[projects]]
   digest = "1:b0c25f00bad20d783d259af2af8666969e2fc343fa0dc9efe52936bbd67fb758"
@@ -674,7 +687,7 @@
     "reflectsource",
   ]
   pruneopts = "UT"
-  revision = "58262d155ee0c659f3e3963bfccbac0f6a6a1d2b"
+  revision = "3fef8c783dec4cbce3bc3b1e877260f0d3c891b7"
 
 [[projects]]
   branch = "master"
@@ -690,15 +703,15 @@
   name = "github.com/shurcooL/graphql"
   packages = ["ident"]
   pruneopts = "UT"
-  revision = "16b88644589aaa174a21ae55cac72a9f60d5d837"
+  revision = "d48a9a75455f6af30244670bc0c9d0e38e7392b5"
 
 [[projects]]
-  digest = "1:69b1cc331fca23d702bd72f860c6a647afd0aa9fcbc1d0659b1365e26546dd70"
+  digest = "1:87c2e02fb01c27060ccc5ba7c5a407cc91147726f8f40b70cceeedbc52b1f3a8"
   name = "github.com/sirupsen/logrus"
   packages = ["."]
   pruneopts = "UT"
-  revision = "bcd833dfe83d3cebad139e4a29ed79cb2318bf95"
-  version = "v1.2.0"
+  revision = "e1e72e9de974bd926e5c56f83753fba2df402ce5"
+  version = "v1.3.0"
 
 [[projects]]
   branch = "master"
@@ -733,7 +746,7 @@
   version = "v1.0.3"
 
 [[projects]]
-  digest = "1:5110e3d4f130772fd39e6ce8208ad1955b242ccfcc8ad9d158857250579c82f4"
+  digest = "1:8ff03ccc603abb0d7cce94d34b613f5f6251a9e1931eba1a3f9888a9029b055c"
   name = "github.com/stretchr/testify"
   packages = [
     "assert",
@@ -741,12 +754,12 @@
     "suite",
   ]
   pruneopts = "UT"
-  revision = "f35b8ab0b5a2cef36673838d662e249dd9c94686"
-  version = "v1.2.2"
+  revision = "ffdc059bfe9ce6a4e144ba849dbedead332c6053"
+  version = "v1.3.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:427cdd2c12a3290ace873d2f9d3958d126c4d75596dbc09de05852da08a3dab5"
+  digest = "1:fba9cce8d6c113fc2e49821ba4a9cc81c38aa7eac68d92955c3095e2c634cdd7"
   name = "golang.org/x/crypto"
   packages = [
     "bcrypt",
@@ -754,18 +767,18 @@
     "ssh/terminal",
   ]
   pruneopts = "UT"
-  revision = "e657309f52e71501f9934566ac06dc5c2f7f11a1"
+  revision = "b8fe1690c61389d7d2a8074a507d1d40c5d30448"
 
 [[projects]]
   branch = "master"
-  digest = "1:1a1ecfa7b54ca3f7a0115ab5c578d7d6a5d8b605839c549e80260468c42f8be7"
+  digest = "1:1235bd185006c1bbdc4292ec1942974469ba1a37ab6bbb73850d75b2bd952efc"
   name = "golang.org/x/net"
   packages = [
     "html",
     "html/atom",
   ]
   pruneopts = "UT"
-  revision = "adae6a3d119ae4890b46832a2e88a95adc62b8e7"
+  revision = "d26f9f9a57f3fab6a695bec0d84433c2c50f8bbf"
 
 [[projects]]
   branch = "master"
@@ -773,34 +786,34 @@
   name = "golang.org/x/sync"
   packages = ["errgroup"]
   pruneopts = "UT"
-  revision = "42b317875d0fa942474b76e1b46a6060d720ae6e"
+  revision = "37e7f081c4d4c64e13b10787722085407fe5d15f"
 
 [[projects]]
   branch = "master"
-  digest = "1:f343f077a5b0bc3a3788b3a04e24dd417e3e25b2acb529c413e212d2c42416ef"
+  digest = "1:a1914323eabb0da3b4392fb0d34b1ae5b6b531323daf4eeddc355d8000982052"
   name = "golang.org/x/sys"
   packages = [
     "unix",
     "windows",
   ]
   pruneopts = "UT"
-  revision = "62eef0e2fa9b2c385f7b2778e763486da6880d37"
+  revision = "41f3e6584952bb034a481797859f6ab34b6803bd"
 
 [[projects]]
   digest = "1:c25289f43ac4a68d88b02245742347c94f1e108c534dda442188015ff80669b3"
   name = "google.golang.org/appengine"
   packages = ["cloudsql"]
   pruneopts = "UT"
-  revision = "4a4468ece617fc8205e99368fa2200e9d1fad421"
-  version = "v1.3.0"
+  revision = "e9657d882bb81064595ca3b56cbe2546bbabf7b1"
+  version = "v1.4.0"
 
 [[projects]]
-  digest = "1:342378ac4dcb378a5448dd723f0784ae519383532f5e70ade24132c4c8693202"
+  digest = "1:4d2e5a73dc1500038e504a8d78b986630e3626dc027bc030ba5c75da257cdb96"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
   pruneopts = "UT"
-  revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
-  version = "v2.2.1"
+  revision = "51d6538a90f86fe93ac480b35f37b2be17fef232"
+  version = "v2.2.2"
 
 [solve-meta]
   analyzer-name = "dep"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,16 @@ This API provides simple restful API access to Amazon's RDS service.
 
 This API uses the standard format for input and output of parameters as defined by the AWS SDK (for reference see https://docs.aws.amazon.com/sdk-for-go/api/service/rds/).
 
+### Config
+
 You can define multiple _accounts_ in your `config.json` file which are mapped to endpoints by the API and allow RDS instances to be created in different AWS accounts. See [example config](config/config.example.json)
+
+In each account you can optionally define certain defaults that will be used if those parameters are not specified in the POST request when creating a database:
+  - `defaultSubnetGroup` - the subnet group that will be used if one is not given
+  - `defaultDBParameterGroupName` - map of ParameterGroupFamily to ParameterGroupName's
+  - `defaultDBClusterParameterGroupName` - map of ParameterGroupFamily to ClusterParameterGroupName's
+
+_Note that any default parameters need to refer to existing resources (groups), i.e. they need to be created separately outside of this API._
 
 ### Creating a database
 

--- a/config/config.example.json
+++ b/config/config.example.json
@@ -10,7 +10,15 @@
       "region": "us-east-1",
       "akid": "AKID",
       "secret": "SECRET",
-      "defaultSubnetGroup": "default-subnets"
+      "defaultSubnetGroup": "default-subnets",
+      "defaultDBParameterGroupName": {
+        "postgres9.6": "my-postgres96",
+        "postgres10": "my-postgres10"
+      },
+      "defaultDBClusterParameterGroupName": {
+        "aurora5.6": "my-aurora56",
+        "aurora-mysql5.7": "my-aurora-mysql57"
+      }
     }
   },
   "token": "TOKEN"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 # This is a multi-stage Dockerfile and requires >= Docker 17.05
 # https://docs.docker.com/engine/userguide/eng-image/multistage-build/
-FROM gobuffalo/buffalo:v0.13.7 as builder
+FROM gobuffalo/buffalo:v0.13.13 as builder
 
 RUN mkdir -p $GOPATH/src/github.com/YaleSpinup/rds-api
 WORKDIR $GOPATH/src/github.com/YaleSpinup/rds-api

--- a/docker/Dockerfile.local
+++ b/docker/Dockerfile.local
@@ -1,6 +1,6 @@
 # This is a multi-stage Dockerfile and requires >= Docker 17.05
 # https://docs.docker.com/engine/userguide/eng-image/multistage-build/
-FROM gobuffalo/buffalo:v0.13.7 as builder
+FROM gobuffalo/buffalo:v0.13.13 as builder
 
 RUN mkdir -p $GOPATH/src/github.com/YaleSpinup/rds-api
 WORKDIR $GOPATH/src/github.com/YaleSpinup/rds-api

--- a/pkg/common/config.go
+++ b/pkg/common/config.go
@@ -18,10 +18,12 @@ type Config struct {
 
 // Account is the configuration for an individual account
 type Account struct {
-	Region             string
-	Akid               string
-	Secret             string
-	DefaultSubnetGroup string
+	Region                             string
+	Akid                               string
+	Secret                             string
+	DefaultSubnetGroup                 string
+	DefaultDBParameterGroupName        map[string]string
+	DefaultDBClusterParameterGroupName map[string]string
 }
 
 // LoadConfig loads the JSON configuration from the specified filename and returns a Config struct

--- a/pkg/rds/client.go
+++ b/pkg/rds/client.go
@@ -13,8 +13,10 @@ import (
 
 // Client struct contains the initialized RDS service and other RDS-related parameters
 type Client struct {
-	Service            rdsiface.RDSAPI
-	DefaultSubnetGroup string
+	Service                            rdsiface.RDSAPI
+	DefaultSubnetGroup                 string
+	DefaultDBParameterGroupName        map[string]string
+	DefaultDBClusterParameterGroupName map[string]string
 }
 
 // NewSession creates an AWS session for RDS and returns an RDSClient
@@ -26,7 +28,9 @@ func NewSession(c common.Account) Client {
 	}))
 
 	return Client{
-		Service:            rds.New(sess),
-		DefaultSubnetGroup: c.DefaultSubnetGroup,
+		Service:                            rds.New(sess),
+		DefaultSubnetGroup:                 c.DefaultSubnetGroup,
+		DefaultDBParameterGroupName:        c.DefaultDBParameterGroupName,
+		DefaultDBClusterParameterGroupName: c.DefaultDBClusterParameterGroupName,
 	}
 }

--- a/pkg/rds/parameter_groups.go
+++ b/pkg/rds/parameter_groups.go
@@ -8,10 +8,11 @@ import (
 
 // DetermineParameterGroupFamily returns the DBParameterGroupFamily based on the
 // given database Engine and EngineVersion
-func (cl Client) DetermineParameterGroupFamily(e, ev *string) (string, error) {
+// e.g. given engine "postgres" and engineVersion "10.5" it will return "postgres10"
+func (cl Client) DetermineParameterGroupFamily(engine, engineVersion *string) (string, error) {
 	input := &rds.DescribeDBEngineVersionsInput{
-		Engine:        e,
-		EngineVersion: ev,
+		Engine:        engine,
+		EngineVersion: engineVersion,
 	}
 
 	evResult, err := cl.Service.DescribeDBEngineVersions(input)

--- a/pkg/rds/parameter_groups.go
+++ b/pkg/rds/parameter_groups.go
@@ -1,0 +1,26 @@
+package rds
+
+import (
+	"errors"
+
+	"github.com/aws/aws-sdk-go/service/rds"
+)
+
+// DetermineParameterGroupFamily returns the DBParameterGroupFamily based on the
+// given database Engine and EngineVersion
+func (cl Client) DetermineParameterGroupFamily(e, ev *string) (string, error) {
+	input := &rds.DescribeDBEngineVersionsInput{
+		Engine:        e,
+		EngineVersion: ev,
+	}
+
+	evResult, err := cl.Service.DescribeDBEngineVersions(input)
+	if err != nil {
+		return "", err
+	}
+	if len(evResult.DBEngineVersions) == 0 {
+		return "", errors.New("Unable to find any matching database engine/version")
+	}
+
+	return *evResult.DBEngineVersions[0].DBParameterGroupFamily, nil
+}


### PR DESCRIPTION
This PR adds support for two new parameters in the config file:
  - DefaultDBParameterGroupName
  - DefaultDBClusterParameterGroupName

They allow for specifying optional mappings of `ParameterGroupFamily` to `ParameterGroupName` which will be used in case the database create request doesn't have a parameter group name. If defaults are not defined the API will fall back to AWS defaults.