### PR TITLE
Add support for Aurora Serverless clusters

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,36 @@ POST http://127.0.0.1:3000/v1/rds/{account}
 
 All cluster creation parameters are listed at https://docs.aws.amazon.com/sdk-for-go/api/service/rds/#CreateDBClusterInput
 
+To create an Aurora serverless cluster you need to pass the `EngineMode` parameter and can optionally specify custom `ScalingConfiguration`:
+
+```
+POST http://127.0.0.1:3000/v1/rds/{account}
+{
+   "Cluster":{
+      "AutoMinorVersionUpgrade":true,
+      "BackupRetentionPeriod":1,
+      "DBClusterIdentifier":"myserverless",
+      "Engine":"aurora-mysql",
+      "EngineMode":"serverless",
+      "MasterUserPassword":"MyPassword",
+      "MasterUsername":"MyUser",
+      "ScalingConfiguration": {
+         "AutoPause": true,
+         "MaxCapacity": 4,
+         "MinCapacity": 1,
+         "SecondsUntilAutoPause": 300
+      },
+      "StorageEncrypted":true,
+      "VpcSecurityGroupIds":[
+         "sg-12345678"
+      ]
+   }
+}
+```
+
 ### Getting details about a database
 
-To get details about a specific database instance:
+To get details about a specific database instance or cluster:
 
 ```
 GET http://127.0.0.1:3000/v1/rds/{account}/mypostgres

--- a/actions/app.go
+++ b/actions/app.go
@@ -42,6 +42,10 @@ var (
 	GitHash = rdsapi.GitHash
 )
 
+type rdsOrchestrator struct {
+	client rds.Client
+}
+
 // App is where all routes and middleware for buffalo should be defined
 func App() *buffalo.App {
 	if app == nil {

--- a/actions/databases.go
+++ b/actions/databases.go
@@ -1,9 +1,10 @@
 package actions
 
 import (
-	"errors"
 	"log"
 	"strconv"
+
+	"github.com/pkg/errors"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -21,6 +22,22 @@ type DatabaseCreateInput struct {
 	Instance *rds.CreateDBInstanceInput
 }
 
+// DatabaseCreateOutput is the output from creating a new database
+type DatabaseCreateOutput struct {
+	// https://docs.aws.amazon.com/sdk-for-go/api/service/rds/#CreateDBClusterOutput
+	Cluster *rds.CreateDBClusterOutput
+	// https://docs.aws.amazon.com/sdk-for-go/api/service/rds/#CreateDBInstanceOutput
+	Instance *rds.CreateDBInstanceOutput
+}
+
+// DatabaseDeleteOutput is the output from deleting a database
+type DatabaseDeleteOutput struct {
+	// https://docs.aws.amazon.com/sdk-for-go/api/service/rds/#DeleteDBClusterOutput
+	Cluster *rds.DeleteDBClusterOutput
+	// https://docs.aws.amazon.com/sdk-for-go/api/service/rds/#DeleteDBInstanceOutput
+	Instance *rds.DeleteDBInstanceOutput
+}
+
 // DatabaseModifyInput is the input for modifying an existing database
 type DatabaseModifyInput struct {
 	// https://docs.aws.amazon.com/sdk-for-go/api/service/rds/#ModifyDBClusterInput
@@ -28,6 +45,14 @@ type DatabaseModifyInput struct {
 	// https://docs.aws.amazon.com/sdk-for-go/api/service/rds/#ModifyDBInstanceInput
 	Instance *rds.ModifyDBInstanceInput
 	Tags     []*rds.Tag
+}
+
+// DatabaseModifyOutput is the output from modifying an existing database
+type DatabaseModifyOutput struct {
+	// https://docs.aws.amazon.com/sdk-for-go/api/service/rds/#ModifyDBClusterOutput
+	Cluster *rds.ModifyDBClusterOutput
+	// https://docs.aws.amazon.com/sdk-for-go/api/service/rds/#ModifyDBInstanceOutput
+	Instance *rds.ModifyDBInstanceOutput
 }
 
 // DatabaseStateInput is the input for changing the database state
@@ -146,9 +171,6 @@ func DatabasesGet(c buffalo.Context) error {
 }
 
 // DatabasesPost creates a database in a given account
-// It will create a database instance as specified by the `Instance` hash parameters.
-// If a `Cluster` hash is also given, it will first create an RDS cluster and the instance next.
-// If only `Cluster` is specified, it will create an RDS cluster (usually for Aurora serverless)
 func DatabasesPost(c buffalo.Context) error {
 	input := DatabaseCreateInput{}
 	if err := c.Bind(&input); err != nil {
@@ -156,118 +178,37 @@ func DatabasesPost(c buffalo.Context) error {
 		return c.Error(400, err)
 	}
 
+	if input.Cluster == nil && input.Instance == nil {
+		return c.Error(400, errors.New("Bad request: specify Cluster or Instance in request"))
+	}
+
 	rdsClient, ok := RDS[c.Param("account")]
 	if !ok {
 		return c.Error(400, errors.New("Bad request: unknown account "+c.Param("account")))
 	}
 
-	var clusterOutput *rds.CreateDBClusterOutput
-	var instanceOutput *rds.CreateDBInstanceOutput
-	var err error
-
-	// create rds cluster first, if specified
-	if input.Cluster != nil {
-		// set default subnet group
-		if input.Cluster.DBSubnetGroupName == nil {
-			input.Cluster.DBSubnetGroupName = aws.String(rdsClient.DefaultSubnetGroup)
-		}
-		// set default cluster parameter group
-		if input.Cluster.DBClusterParameterGroupName == nil {
-			pgFamily, pgErr := rdsClient.DetermineParameterGroupFamily(input.Cluster.Engine, input.Cluster.EngineVersion)
-			if pgErr != nil {
-				log.Println(pgErr.Error())
-				return c.Error(400, pgErr)
-			}
-			log.Println("Determined ParameterGroupFamily based on Engine:", pgFamily)
-			cPg, ok := rdsClient.DefaultDBClusterParameterGroupName[pgFamily]
-			if !ok {
-				log.Println("No matching DefaultDBClusterParameterGroupName found in config, using AWS default PG")
-			} else {
-				log.Println("Using DefaultDBClusterParameterGroupName:", cPg)
-				input.Cluster.DBClusterParameterGroupName = aws.String(cPg)
-			}
-		}
-
-		input.Cluster.Tags = normalizeTags(input.Cluster.Tags)
-		if clusterOutput, err = rdsClient.Service.CreateDBClusterWithContext(c, input.Cluster); err != nil {
-			log.Println(err.Error())
-			if aerr, ok := err.(awserr.Error); ok {
-				return c.Error(400, aerr)
-			}
-			return err
-		}
-		log.Println("Created RDS cluster", clusterOutput)
+	orch := &rdsOrchestrator{
+		client: rdsClient,
 	}
 
-	// create rds instance, if specified
-	if input.Instance != nil {
-		// set default subnet group
-		if input.Instance.DBSubnetGroupName == nil {
-			input.Instance.DBSubnetGroupName = aws.String(rdsClient.DefaultSubnetGroup)
-		}
-		// set default parameter group
-		if input.Instance.DBParameterGroupName == nil {
-			pgFamily, pgErr := rdsClient.DetermineParameterGroupFamily(input.Instance.Engine, input.Instance.EngineVersion)
-			if pgErr != nil {
-				log.Println(pgErr.Error())
-				return c.Error(400, pgErr)
-			}
-			log.Println("Determined ParameterGroupFamily based on Engine:", pgFamily)
-			pg, ok := rdsClient.DefaultDBParameterGroupName[pgFamily]
-			if !ok {
-				log.Println("No matching DefaultDBParameterGroupName found in config, using AWS default PG")
-			} else {
-				log.Println("Using DefaultDBParameterGroupName:", pg)
-				input.Instance.DBParameterGroupName = aws.String(pg)
-			}
-		}
-
-		input.Instance.Tags = normalizeTags(input.Instance.Tags)
-		if instanceOutput, err = rdsClient.Service.CreateDBInstanceWithContext(c, input.Instance); err != nil {
-			log.Println(err.Error())
-			if input.Cluster != nil {
-				// if this instance was in a new cluster, delete the cluster
-				log.Println("Deleting cluster", *input.Cluster.DBClusterIdentifier)
-				clusterInput := &rds.DeleteDBClusterInput{
-					DBClusterIdentifier: input.Cluster.DBClusterIdentifier,
-					SkipFinalSnapshot:   aws.Bool(true),
-				}
-				if _, errc := rdsClient.Service.DeleteDBClusterWithContext(c, clusterInput); errc != nil {
-					log.Println("Failed to delete cluster", errc.Error())
-				} else {
-					log.Println("Successfully requested deletion of cluster", *input.Cluster.DBClusterIdentifier)
-				}
-			}
-			if aerr, ok := err.(awserr.Error); ok {
-				return c.Error(400, aerr)
-			}
-			return err
-		}
-		log.Println("Created RDS instance", instanceOutput)
+	resp, err := orch.databaseCreate(c, &input)
+	if err != nil {
+		return c.Error(400, errors.Wrap(err, "failed to create database"))
 	}
 
-	output := struct {
-		*rds.CreateDBClusterOutput
-		*rds.CreateDBInstanceOutput
-	}{
-		clusterOutput,
-		instanceOutput,
-	}
-
-	return c.Render(200, r.JSON(output))
+	return c.Render(200, r.JSON(resp))
 }
 
 // DatabasesPut modifies a database in a given account
-// Either Cluster or Instance input parameters can be specified for a request
-// Tags list can be given with any key/value tags to add/update
 func DatabasesPut(c buffalo.Context) error {
 	input := DatabaseModifyInput{}
 	if err := c.Bind(&input); err != nil {
 		log.Println(err)
 		return c.Error(400, err)
 	}
+
 	if input.Cluster == nil && input.Instance == nil && input.Tags == nil {
-		return c.Error(400, errors.New("Bad request"))
+		return c.Error(400, errors.New("Bad request: missing Cluster, Instance, Tags in request"))
 	}
 
 	if input.Cluster != nil && input.Instance != nil {
@@ -279,67 +220,16 @@ func DatabasesPut(c buffalo.Context) error {
 		return c.Error(400, errors.New("Bad request: unknown account "+c.Param("account")))
 	}
 
-	var clusterOutput *rds.ModifyDBClusterOutput
-	var instanceOutput *rds.ModifyDBInstanceOutput
-	var err error
-
-	if input.Cluster != nil {
-		input.Cluster.DBClusterIdentifier = aws.String(c.Param("db"))
-		if clusterOutput, err = rdsClient.Service.ModifyDBClusterWithContext(c, input.Cluster); err != nil {
-			log.Println(err.Error())
-			if aerr, ok := err.(awserr.Error); ok {
-				return c.Error(400, aerr)
-			}
-			return err
-		}
-		log.Println("Modified RDS cluster", clusterOutput)
+	orch := &rdsOrchestrator{
+		client: rdsClient,
 	}
 
-	if input.Instance != nil {
-		input.Instance.DBInstanceIdentifier = aws.String(c.Param("db"))
-		if instanceOutput, err = rdsClient.Service.ModifyDBInstanceWithContext(c, input.Instance); err != nil {
-			log.Println(err.Error())
-			if aerr, ok := err.(awserr.Error); ok {
-				return c.Error(400, aerr)
-			}
-			return err
-		}
-		log.Println("Modified RDS instance", instanceOutput)
+	resp, err := orch.databaseModify(c, c.Param("db"), &input)
+	if err != nil {
+		return c.Error(400, errors.Wrap(err, "failed to modify database"))
 	}
 
-	if input.Tags != nil {
-		log.Println("Updating tags for "+c.Param("db"), input.Tags)
-
-		// determine ARN(s) for this RDS resource
-		arns, err := rdsClient.DetermineArn(c.Param("db"))
-		if err != nil {
-			log.Println(err)
-			return c.Error(400, err)
-		}
-
-		normalizedTags := normalizeTags(input.Tags)
-
-		// update tags for all RDS resources with matching ARNs
-		for _, arn := range arns {
-			if _, err = rdsClient.Service.AddTagsToResourceWithContext(c, &rds.AddTagsToResourceInput{
-				ResourceName: aws.String(arn),
-				Tags:         normalizedTags,
-			}); err != nil {
-				return c.Error(400, err)
-			}
-			log.Println("Updated tags for RDS resource", arn)
-		}
-	}
-
-	output := struct {
-		*rds.ModifyDBClusterOutput
-		*rds.ModifyDBInstanceOutput
-	}{
-		clusterOutput,
-		instanceOutput,
-	}
-
-	return c.Render(200, r.JSON(output))
+	return c.Render(200, r.JSON(resp))
 }
 
 // DatabasesPutState stops or starts a database in a given account
@@ -377,11 +267,7 @@ func DatabasesPutState(c buffalo.Context) error {
 }
 
 // DatabasesDelete deletes a database in a given account
-// It will delete the database instance with the given {db} name and will also delete the associated cluster
-//  if the instance belongs to a cluster and is the last remaining member.
-// If the snapshot=true parameter is given, it will create a final snapshot of the instance/cluster.
 func DatabasesDelete(c buffalo.Context) error {
-	// if snapshot param is given, a final snapshot will be created before deleting
 	snapshot := false
 	if b, err := strconv.ParseBool(c.Param("snapshot")); err == nil {
 		snapshot = b
@@ -392,154 +278,14 @@ func DatabasesDelete(c buffalo.Context) error {
 		return c.Error(400, errors.New("Bad request: unknown account "+c.Param("account")))
 	}
 
-	var clusterOutput *rds.DeleteDBClusterOutput
-	var instanceOutput *rds.DeleteDBInstanceOutput
-	var err error
-	var clusterName *string
-	instanceNotFound := false
+	orch := &rdsOrchestrator{
+		client: rdsClient,
+	}
 
-	// first, let's determine if the given database instance belongs to a cluster
-	i, err := rdsClient.Service.DescribeDBInstancesWithContext(c, &rds.DescribeDBInstancesInput{
-		DBInstanceIdentifier: aws.String(c.Param("db")),
-	})
+	resp, err := orch.databaseDelete(c, c.Param("db"), snapshot)
 	if err != nil {
-		log.Println(err.Error())
-		if aerr, ok := err.(awserr.Error); ok {
-			if aerr.Code() == rds.ErrCodeDBInstanceNotFoundFault {
-				log.Printf("No matching database instance found: %s", c.Param("db"))
-				instanceNotFound = true
-			} else {
-				return c.Error(400, aerr)
-			}
-		}
+		return c.Error(400, errors.Wrap(err, "failed to delete database"))
 	}
 
-	if i != nil && !instanceNotFound {
-		if len(i.DBInstances) > 1 {
-			return c.Error(400, errors.New("Unexpected number of DBInstances"))
-		}
-		if len(i.DBInstances) < 1 {
-			return c.Error(400, errors.New("No DBInstances found"))
-		}
-		if i.DBInstances[0].DBClusterIdentifier != nil {
-			clusterName = i.DBInstances[0].DBClusterIdentifier
-		}
-
-		instanceInput := &rds.DeleteDBInstanceInput{
-			DBInstanceIdentifier: aws.String(c.Param("db")),
-			SkipFinalSnapshot:    aws.Bool(true),
-		}
-
-		if snapshot && clusterName == nil {
-			log.Printf("Deleting database %s and creating final snapshot", c.Param("db"))
-			instanceInput.FinalDBSnapshotIdentifier = aws.String("final-" + c.Param("db"))
-			instanceInput.SkipFinalSnapshot = aws.Bool(false)
-		} else {
-			log.Printf("Deleting database %s without creating final snapshot", c.Param("db"))
-		}
-
-		if instanceOutput, err = rdsClient.Service.DeleteDBInstanceWithContext(c, instanceInput); err != nil {
-			log.Println(err.Error())
-			if aerr, ok := err.(awserr.Error); ok {
-				if aerr.Code() == rds.ErrCodeDBInstanceNotFoundFault {
-					return c.Error(404, aerr)
-				}
-				return c.Error(400, aerr)
-			}
-			return err
-		}
-		log.Println("Successfully requested deletion of database instance", c.Param("db"), instanceOutput)
-	}
-
-	// check if this database instance was part of a cluster
-	// and delete the cluster (if this was the last member instance)
-	if clusterName != nil && !instanceNotFound {
-		clusterInput := &rds.DeleteDBClusterInput{
-			DBClusterIdentifier: clusterName,
-			SkipFinalSnapshot:   aws.Bool(true),
-		}
-
-		if snapshot {
-			log.Printf("Trying to delete associated database cluster %s with final snapshot", *clusterName)
-			clusterInput.FinalDBSnapshotIdentifier = aws.String("final-" + *clusterName)
-			clusterInput.SkipFinalSnapshot = aws.Bool(false)
-		} else {
-			log.Printf("Trying to delete associated database cluster %s", *clusterName)
-		}
-
-		// the cluster deletion will fail if there are still member instances in the cluster
-		if clusterOutput, err = rdsClient.Service.DeleteDBClusterWithContext(c, clusterInput); err != nil {
-			if aerr, ok := err.(awserr.Error); ok {
-				if aerr.Code() == rds.ErrCodeDBClusterNotFoundFault {
-					log.Println(rds.ErrCodeDBClusterNotFoundFault, aerr.Error())
-				} else {
-					log.Println(aerr.Error())
-				}
-			} else {
-				log.Println(err.Error())
-			}
-		} else {
-			log.Println("Successfully requested deletion of database cluster", *clusterName, clusterOutput)
-		}
-	}
-
-	// delete cluster (with no associated instances)
-	if instanceNotFound {
-		clusterName = aws.String(c.Param("db"))
-		clusterInput := &rds.DeleteDBClusterInput{
-			DBClusterIdentifier: clusterName,
-			SkipFinalSnapshot:   aws.Bool(true),
-		}
-
-		if snapshot {
-			log.Printf("Trying to delete database cluster %s with final snapshot", *clusterName)
-			clusterInput.FinalDBSnapshotIdentifier = aws.String("final-" + *clusterName)
-			clusterInput.SkipFinalSnapshot = aws.Bool(false)
-		} else {
-			log.Printf("Trying to delete database cluster %s", *clusterName)
-		}
-
-		if clusterOutput, err = rdsClient.Service.DeleteDBClusterWithContext(c, clusterInput); err != nil {
-			if aerr, ok := err.(awserr.Error); ok {
-				if aerr.Code() == rds.ErrCodeDBClusterNotFoundFault {
-					log.Println(rds.ErrCodeDBClusterNotFoundFault, aerr.Error())
-				} else {
-					log.Println(aerr.Error())
-				}
-			} else {
-				log.Println(err.Error())
-			}
-		} else {
-			log.Println("Successfully requested deletion of database cluster", *clusterName, clusterOutput)
-		}
-	}
-
-	output := struct {
-		*rds.DeleteDBClusterOutput
-		*rds.DeleteDBInstanceOutput
-	}{
-		clusterOutput,
-		instanceOutput,
-	}
-
-	return c.Render(200, r.JSON(output))
-}
-
-// normalizeTags strips the org from the given tags and ensures it is set to the API org
-func normalizeTags(tags []*rds.Tag) []*rds.Tag {
-	normalizedTags := []*rds.Tag{}
-	for _, t := range tags {
-		if aws.StringValue(t.Key) == "spinup:org" || aws.StringValue(t.Key) == "yale:org" {
-			continue
-		}
-		normalizedTags = append(normalizedTags, t)
-	}
-
-	normalizedTags = append(normalizedTags,
-		&rds.Tag{
-			Key:   aws.String("spinup:org"),
-			Value: aws.String(AppConfig.Org),
-		})
-
-	return normalizedTags
+	return c.Render(200, r.JSON(resp))
 }

--- a/actions/orchestration.go
+++ b/actions/orchestration.go
@@ -1,0 +1,309 @@
+package actions
+
+import (
+	"errors"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/gobuffalo/buffalo"
+)
+
+// databaseCreate orchestrates the creation of a repository from the DatabaseCreateInput
+// It will create a database instance as specified by the `Instance` hash parameters.
+// If a `Cluster` hash is also given, it will first create an RDS cluster and the instance next.
+// If only `Cluster` is specified, it will create an RDS cluster (usually for Aurora serverless)
+func (o *rdsOrchestrator) databaseCreate(c buffalo.Context, input *DatabaseCreateInput) (*DatabaseCreateOutput, error) {
+	log.Printf("creating database with input %+v", input)
+
+	var clusterOutput *rds.CreateDBClusterOutput
+	var instanceOutput *rds.CreateDBInstanceOutput
+	var err error
+
+	// create rds cluster first, if specified
+	if input.Cluster != nil {
+		// set default subnet group
+		if input.Cluster.DBSubnetGroupName == nil {
+			input.Cluster.DBSubnetGroupName = aws.String(o.client.DefaultSubnetGroup)
+		}
+		// set default cluster parameter group
+		if input.Cluster.DBClusterParameterGroupName == nil {
+			pgFamily, pgErr := o.client.DetermineParameterGroupFamily(input.Cluster.Engine, input.Cluster.EngineVersion)
+			if pgErr != nil {
+				log.Println(pgErr.Error())
+				return nil, pgErr
+			}
+			log.Println("Determined ParameterGroupFamily based on Engine:", pgFamily)
+			cPg, ok := o.client.DefaultDBClusterParameterGroupName[pgFamily]
+			if !ok {
+				log.Println("No matching DefaultDBClusterParameterGroupName found in config, using AWS default PG")
+			} else {
+				log.Println("Using DefaultDBClusterParameterGroupName:", cPg)
+				input.Cluster.DBClusterParameterGroupName = aws.String(cPg)
+			}
+		}
+
+		input.Cluster.Tags = normalizeTags(input.Cluster.Tags)
+		if clusterOutput, err = o.client.Service.CreateDBClusterWithContext(c, input.Cluster); err != nil {
+			log.Println(err.Error())
+			if aerr, ok := err.(awserr.Error); ok {
+				return nil, aerr
+			}
+			return nil, err
+		}
+		log.Println("Created RDS cluster", clusterOutput)
+	}
+
+	// create rds instance, if specified
+	if input.Instance != nil {
+		// set default subnet group
+		if input.Instance.DBSubnetGroupName == nil {
+			input.Instance.DBSubnetGroupName = aws.String(o.client.DefaultSubnetGroup)
+		}
+		// set default parameter group
+		if input.Instance.DBParameterGroupName == nil {
+			pgFamily, pgErr := o.client.DetermineParameterGroupFamily(input.Instance.Engine, input.Instance.EngineVersion)
+			if pgErr != nil {
+				log.Println(pgErr.Error())
+				return nil, pgErr
+			}
+			log.Println("Determined ParameterGroupFamily based on Engine:", pgFamily)
+			if pg, ok := o.client.DefaultDBParameterGroupName[pgFamily]; ok {
+				log.Println("Using DefaultDBParameterGroupName:", pg)
+				input.Instance.DBParameterGroupName = aws.String(pg)
+			}
+		}
+
+		input.Instance.Tags = normalizeTags(input.Instance.Tags)
+		if instanceOutput, err = o.client.Service.CreateDBInstanceWithContext(c, input.Instance); err != nil {
+			log.Println(err.Error())
+			if input.Cluster != nil {
+				// if this instance was in a new cluster, delete the cluster
+				log.Println("Deleting cluster", *input.Cluster.DBClusterIdentifier)
+				clusterInput := &rds.DeleteDBClusterInput{
+					DBClusterIdentifier: input.Cluster.DBClusterIdentifier,
+					SkipFinalSnapshot:   aws.Bool(true),
+				}
+				if _, errc := o.client.Service.DeleteDBClusterWithContext(c, clusterInput); errc != nil {
+					log.Println("Failed to delete cluster", errc.Error())
+				} else {
+					log.Println("Successfully requested deletion of cluster", *input.Cluster.DBClusterIdentifier)
+				}
+			}
+			if aerr, ok := err.(awserr.Error); ok {
+				return nil, aerr
+			}
+			return nil, err
+		}
+		log.Println("Created RDS instance", instanceOutput)
+	}
+
+	return &DatabaseCreateOutput{clusterOutput, instanceOutput}, nil
+}
+
+// databaseModify modifies database parameters and tags
+// Either Cluster or Instance input parameters can be specified for a request
+// Tags list can be given with any key/value tags to add/update
+func (o *rdsOrchestrator) databaseModify(c buffalo.Context, id string, input *DatabaseModifyInput) (*DatabaseModifyOutput, error) {
+	log.Printf("modifying database %s with input %+v", id, input)
+
+	var clusterOutput *rds.ModifyDBClusterOutput
+	var instanceOutput *rds.ModifyDBInstanceOutput
+	var err error
+
+	if input.Cluster != nil {
+		input.Cluster.DBClusterIdentifier = aws.String(id)
+		if clusterOutput, err = o.client.Service.ModifyDBClusterWithContext(c, input.Cluster); err != nil {
+			log.Println(err.Error())
+			if aerr, ok := err.(awserr.Error); ok {
+				return nil, aerr
+			}
+			return nil, err
+		}
+		log.Println("Modified RDS cluster", clusterOutput)
+	}
+
+	if input.Instance != nil {
+		input.Instance.DBInstanceIdentifier = aws.String(id)
+		if instanceOutput, err = o.client.Service.ModifyDBInstanceWithContext(c, input.Instance); err != nil {
+			log.Println(err.Error())
+			if aerr, ok := err.(awserr.Error); ok {
+				return nil, aerr
+			}
+			return nil, err
+		}
+		log.Println("Modified RDS instance", instanceOutput)
+	}
+
+	if input.Tags != nil {
+		log.Println("Updating tags for "+id, input.Tags)
+
+		// determine ARN(s) for this RDS resource
+		arns, err := o.client.DetermineArn(id)
+		if err != nil {
+			log.Println(err)
+			return nil, err
+		}
+
+		normalizedTags := normalizeTags(input.Tags)
+
+		// update tags for all RDS resources with matching ARNs
+		for _, arn := range arns {
+			if _, err = o.client.Service.AddTagsToResourceWithContext(c, &rds.AddTagsToResourceInput{
+				ResourceName: aws.String(arn),
+				Tags:         normalizedTags,
+			}); err != nil {
+				return nil, err
+			}
+			log.Println("Updated tags for RDS resource", arn)
+		}
+	}
+
+	return &DatabaseModifyOutput{clusterOutput, instanceOutput}, nil
+}
+
+// databaseDelete deletes a database
+// It will delete the database instance with the given {db} name and will also delete the associated cluster
+//  if the instance belongs to a cluster and is the last remaining member.
+// If snapshot is true, it will create a final snapshot of the instance/cluster.
+func (o *rdsOrchestrator) databaseDelete(c buffalo.Context, id string, snapshot bool) (*DatabaseDeleteOutput, error) {
+	log.Printf("deleting database %s (snapshot: %t)", id, snapshot)
+
+	var clusterOutput *rds.DeleteDBClusterOutput
+	var instanceOutput *rds.DeleteDBInstanceOutput
+	var err error
+	var clusterName *string
+	var instanceNotFound bool
+
+	// first, let's determine if the given database instance belongs to a cluster
+	describeInstanceOutput, err := o.client.Service.DescribeDBInstancesWithContext(c, &rds.DescribeDBInstancesInput{
+		DBInstanceIdentifier: aws.String(id),
+	})
+	if err != nil {
+		log.Println(err.Error())
+		if aerr, ok := err.(awserr.Error); ok {
+			if aerr.Code() == rds.ErrCodeDBInstanceNotFoundFault {
+				log.Printf("No matching database instance found: %s", id)
+				instanceNotFound = true
+			} else {
+				return nil, aerr
+			}
+		}
+	}
+
+	// if a db instance exists, delete it
+	if describeInstanceOutput != nil && !instanceNotFound {
+		if len(describeInstanceOutput.DBInstances) > 1 {
+			return nil, errors.New("Unexpected number of DBInstances")
+		}
+		if len(describeInstanceOutput.DBInstances) < 1 {
+			return nil, errors.New("No DBInstances found")
+		}
+		if describeInstanceOutput.DBInstances[0].DBClusterIdentifier != nil {
+			clusterName = describeInstanceOutput.DBInstances[0].DBClusterIdentifier
+		}
+
+		instanceInput := &rds.DeleteDBInstanceInput{
+			DBInstanceIdentifier: aws.String(id),
+			SkipFinalSnapshot:    aws.Bool(true),
+		}
+
+		if snapshot && clusterName == nil {
+			log.Printf("Deleting database %s and creating final snapshot", id)
+			instanceInput.FinalDBSnapshotIdentifier = aws.String("final-" + id)
+			instanceInput.SkipFinalSnapshot = aws.Bool(false)
+		} else {
+			log.Printf("Deleting database %s without creating final snapshot", id)
+		}
+
+		if instanceOutput, err = o.client.Service.DeleteDBInstanceWithContext(c, instanceInput); err != nil {
+			log.Println(err.Error())
+			if aerr, ok := err.(awserr.Error); ok {
+				return nil, aerr
+			}
+			return nil, err
+		}
+		log.Println("Successfully requested deletion of database instance", id, instanceOutput)
+	}
+
+	// check if this db instance was part of a cluster
+	// and delete the cluster, if this was the last member instance
+	if clusterName != nil && !instanceNotFound {
+		clusterInput := &rds.DeleteDBClusterInput{
+			DBClusterIdentifier: clusterName,
+			SkipFinalSnapshot:   aws.Bool(true),
+		}
+
+		if snapshot {
+			log.Printf("Trying to delete associated database cluster %s with final snapshot", *clusterName)
+			clusterInput.FinalDBSnapshotIdentifier = aws.String("final-" + *clusterName)
+			clusterInput.SkipFinalSnapshot = aws.Bool(false)
+		} else {
+			log.Printf("Trying to delete associated database cluster %s", *clusterName)
+		}
+
+		// the cluster deletion will fail if there are still member instances in the cluster
+		if clusterOutput, err = o.client.Service.DeleteDBClusterWithContext(c, clusterInput); err != nil {
+			if aerr, ok := err.(awserr.Error); ok {
+				if aerr.Code() == rds.ErrCodeDBClusterNotFoundFault {
+					log.Println(rds.ErrCodeDBClusterNotFoundFault, aerr.Error())
+				} else {
+					log.Println(aerr.Error())
+				}
+			} else {
+				log.Println(err.Error())
+			}
+		} else {
+			log.Println("Successfully requested deletion of database cluster", *clusterName, clusterOutput)
+		}
+	}
+
+	// delete cluster (with no associated instances)
+	if instanceNotFound {
+		clusterName = aws.String(id)
+		clusterInput := &rds.DeleteDBClusterInput{
+			DBClusterIdentifier: clusterName,
+			SkipFinalSnapshot:   aws.Bool(true),
+		}
+
+		if snapshot {
+			log.Printf("Trying to delete database cluster %s with final snapshot", *clusterName)
+			clusterInput.FinalDBSnapshotIdentifier = aws.String("final-" + *clusterName)
+			clusterInput.SkipFinalSnapshot = aws.Bool(false)
+		} else {
+			log.Printf("Trying to delete database cluster %s", *clusterName)
+		}
+
+		if clusterOutput, err = o.client.Service.DeleteDBClusterWithContext(c, clusterInput); err != nil {
+			log.Println(err.Error())
+			if aerr, ok := err.(awserr.Error); ok {
+				return nil, aerr
+			}
+			return nil, err
+		}
+
+		log.Println("Successfully requested deletion of database cluster", *clusterName, clusterOutput)
+	}
+
+	return &DatabaseDeleteOutput{clusterOutput, instanceOutput}, nil
+}
+
+// normalizeTags strips the org from the given tags and ensures it is set to the API org
+func normalizeTags(tags []*rds.Tag) []*rds.Tag {
+	normalizedTags := []*rds.Tag{}
+	for _, t := range tags {
+		if aws.StringValue(t.Key) == "spinup:org" || aws.StringValue(t.Key) == "yale:org" {
+			continue
+		}
+		normalizedTags = append(normalizedTags, t)
+	}
+
+	normalizedTags = append(normalizedTags,
+		&rds.Tag{
+			Key:   aws.String("spinup:org"),
+			Value: aws.String(AppConfig.Org),
+		})
+
+	return normalizedTags
+}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.14
 
 require (
 	github.com/Masterminds/semver/v3 v3.1.0 // indirect
-	github.com/YaleSpinup/apierror v0.1.0
 	github.com/aws/aws-sdk-go v1.33.9
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
 	github.com/gobuffalo/buffalo v0.16.13
@@ -27,7 +26,6 @@ require (
 	github.com/monoculum/formam v0.0.0-20200527175922-6f3cce7a46cf // indirect
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/pkg/errors v0.9.1
-	github.com/prometheus/common v0.4.0
 	github.com/rogpeppe/go-internal v1.6.0 // indirect
 	github.com/rs/cors v1.7.0
 	github.com/shopspring/decimal v1.2.0 // indirect
@@ -38,7 +36,6 @@ require (
 	golang.org/x/net v0.0.0-20200707034311-ab3426394381 // indirect
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208 // indirect
 	golang.org/x/sys v0.0.0-20200720211630-cb9d2d5c5666 // indirect
-	google.golang.org/appengine v1.6.5
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
 	gopkg.in/yaml.v2 v2.3.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 // indirect

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.14
 
 require (
 	github.com/Masterminds/semver/v3 v3.1.0 // indirect
+	github.com/YaleSpinup/apierror v0.1.0
 	github.com/aws/aws-sdk-go v1.33.9
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
 	github.com/gobuffalo/buffalo v0.16.13
@@ -26,6 +27,7 @@ require (
 	github.com/monoculum/formam v0.0.0-20200527175922-6f3cce7a46cf // indirect
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/pkg/errors v0.9.1
+	github.com/prometheus/common v0.4.0
 	github.com/rogpeppe/go-internal v1.6.0 // indirect
 	github.com/rs/cors v1.7.0
 	github.com/shopspring/decimal v1.2.0 // indirect
@@ -36,6 +38,7 @@ require (
 	golang.org/x/net v0.0.0-20200707034311-ab3426394381 // indirect
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208 // indirect
 	golang.org/x/sys v0.0.0-20200720211630-cb9d2d5c5666 // indirect
+	google.golang.org/appengine v1.6.5
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
 	gopkg.in/yaml.v2 v2.3.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 // indirect

--- a/go.sum
+++ b/go.sum
@@ -29,10 +29,14 @@ github.com/Masterminds/semver/v3 v3.0.3/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0
 github.com/Masterminds/semver/v3 v3.1.0 h1:Y2lUDsFKVRSYGojLJ1yLxSXdMmMYTYls0rCvoqmMUQk=
 github.com/Masterminds/semver/v3 v3.1.0/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
+github.com/YaleSpinup/apierror v0.1.0 h1:XiL1AQTsZ9ariWE1BngpDeG+YZjQFX/a/OX25AkWQj8=
+github.com/YaleSpinup/apierror v0.1.0/go.mod h1:m68Zb59VAV7MUGwzcYe6vb/FU/DO/QGMbFumkHoyQMQ=
 github.com/ajg/form v0.0.0-20160822230020-523a5da1a92f h1:zvClvFQwU++UpIUBGC8YmDlfhUrweEy1R1Fj1gu5iIM=
 github.com/ajg/form v0.0.0-20160822230020-523a5da1a92f/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY=
 github.com/ajg/form v1.5.1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY=
+github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc h1:cAKDfWh5VpdgMhJosfJnn5/FoN2SRZ4p7fJNX58YPaU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
+github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf h1:qet1QNfXsQxTZqLG4oE62mJzwPIB8+Tee4RNCL9ulrY=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
@@ -655,6 +659,7 @@ github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1 h1:YF8+flBXS5eO826T4nzqPrxfhQThhXl0YzfuUPu4SBg=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/gomodule/redigo v2.0.0+incompatible/go.mod h1:B4C85qUVwatsJoIUNIfCRsp7qO0iAmpGFZ4EELWSbC4=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
@@ -1009,6 +1014,7 @@ github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/common v0.0.0-20180801064454-c7de2306084e/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
 github.com/prometheus/common v0.0.0-20181113130724-41aa239b4cce/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
+github.com/prometheus/common v0.4.0 h1:7etb9YClo3a6HjLzfl6rIQaU+FDfi0VSX39io3aQ+DM=
 github.com/prometheus/common v0.4.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
 github.com/prometheus/procfs v0.0.0-20180725123919-05ee40e3a273/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
@@ -1454,6 +1460,7 @@ google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7
 google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.6.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.6.1/go.mod h1:i06prIuMbXzDqacNJfV5OdTW448YApPu5ww/cMBSeb0=
+google.golang.org/appengine v1.6.5 h1:tycE03LOZYQNhDpS27tcQdAzLCVMaj7QT2SXxebnpCM=
 google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20180831171423-11092d34479b/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
@@ -1476,6 +1483,7 @@ google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiq
 google.golang.org/grpc v1.21.0/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=
 google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=
+gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc/go.mod h1:m7x9LTH6d71AHyAX77c9yqWCCa3UKHcVEj9y7hAtKDk=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/go.sum
+++ b/go.sum
@@ -29,8 +29,6 @@ github.com/Masterminds/semver/v3 v3.0.3/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0
 github.com/Masterminds/semver/v3 v3.1.0 h1:Y2lUDsFKVRSYGojLJ1yLxSXdMmMYTYls0rCvoqmMUQk=
 github.com/Masterminds/semver/v3 v3.1.0/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
-github.com/YaleSpinup/apierror v0.1.0 h1:XiL1AQTsZ9ariWE1BngpDeG+YZjQFX/a/OX25AkWQj8=
-github.com/YaleSpinup/apierror v0.1.0/go.mod h1:m68Zb59VAV7MUGwzcYe6vb/FU/DO/QGMbFumkHoyQMQ=
 github.com/ajg/form v0.0.0-20160822230020-523a5da1a92f h1:zvClvFQwU++UpIUBGC8YmDlfhUrweEy1R1Fj1gu5iIM=
 github.com/ajg/form v0.0.0-20160822230020-523a5da1a92f/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY=
 github.com/ajg/form v1.5.1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY=


### PR DESCRIPTION
This change is basically to allow handling RDS clusters. Until now we had Instances, or Cluster+Instances, but now we can support Cluster without Instances which is required for Aurora Serverless.
The actual creation and management of Serverless clusters is accomplished by passing the appropriate inputs as documented by AWS.