### PR TITLE
Bug Fix: SQL Standard Server creation failing due to LicenseModel

### DIFF
--- a/actions/orchestration.go
+++ b/actions/orchestration.go
@@ -363,6 +363,11 @@ func (o *rdsOrchestrator) databaseCreate(c buffalo.Context, req *DatabaseCreateR
 			VpcSecurityGroupIds:         req.Instance.VpcSecurityGroupIds,
 		}
 
+		// Check for LicenseModel - Required for Microsoft SQL Server Standard
+		if req.Instance.LicenseModel != nil {
+			input.LicenseModel = req.Instance.LicenseModel
+		}
+
 		if instanceOutput, err = o.client.Service.CreateDBInstanceWithContext(c, input); err != nil {
 			if req.Cluster != nil {
 				// if this instance was in a new cluster, delete the cluster

--- a/actions/types.go
+++ b/actions/types.go
@@ -38,6 +38,7 @@ type CreateDBInstanceInput struct {
 	EnableCloudwatchLogsExports []*string
 	Engine                      *string
 	EngineVersion               *string
+	LicenseModel                *string
 	MasterUserPassword          *string
 	MasterUsername              *string
 	MultiAZ                     *bool


### PR DESCRIPTION
* Fixes an issue where SQL Standard Servers were failing due to missing LicenseModel property on the request. This has been fixed