### PR TITLE
Support Serverless V2

### DIFF
--- a/actions/orchestration.go
+++ b/actions/orchestration.go
@@ -298,6 +298,7 @@ func (o *rdsOrchestrator) databaseCreate(c buffalo.Context, req *DatabaseCreateR
 			VpcSecurityGroupIds:         req.Cluster.VpcSecurityGroupIds,
 		}
 
+		// Handle Serverless V1
 		if req.Cluster.ScalingConfiguration != nil {
 			input.ScalingConfiguration = &rds.ScalingConfiguration{
 				AutoPause:             req.Cluster.ScalingConfiguration.AutoPause,
@@ -305,6 +306,14 @@ func (o *rdsOrchestrator) databaseCreate(c buffalo.Context, req *DatabaseCreateR
 				MinCapacity:           req.Cluster.ScalingConfiguration.MinCapacity,
 				SecondsUntilAutoPause: req.Cluster.ScalingConfiguration.SecondsUntilAutoPause,
 				TimeoutAction:         req.Cluster.ScalingConfiguration.TimeoutAction,
+			}
+		}
+
+		// Handle Serverless V2
+		if req.Cluster.ServerlessV2ScalingConfiguration != nil {
+			input.ServerlessV2ScalingConfiguration = &rds.ServerlessV2ScalingConfiguration{
+				MaxCapacity: req.Cluster.ServerlessV2ScalingConfiguration.MaxCapacity,
+				MinCapacity: req.Cluster.ServerlessV2ScalingConfiguration.MinCapacity,
 			}
 		}
 

--- a/actions/types.go
+++ b/actions/types.go
@@ -52,22 +52,23 @@ type CreateDBInstanceInput struct {
 // CreateDBClusterInput is the input for creating a new database cluster
 // based on https://docs.aws.amazon.com/sdk-for-go/api/service/rds/#CreateDBClusterInput
 type CreateDBClusterInput struct {
-	BackupRetentionPeriod       *int64
-	DBClusterIdentifier         *string
-	DBClusterParameterGroupName *string
-	DBSubnetGroupName           *string
-	EnableCloudwatchLogsExports []*string
-	Engine                      *string
-	EngineMode                  *string
-	EngineVersion               *string
-	MasterUserPassword          *string
-	MasterUsername              *string
-	Port                        *int64
-	ScalingConfiguration        *ScalingConfiguration
-	SnapshotIdentifier          *string
-	StorageEncrypted            *bool
-	Tags                        []*Tag
-	VpcSecurityGroupIds         []*string
+	BackupRetentionPeriod            *int64
+	DBClusterIdentifier              *string
+	DBClusterParameterGroupName      *string
+	DBSubnetGroupName                *string
+	EnableCloudwatchLogsExports      []*string
+	Engine                           *string
+	EngineMode                       *string
+	EngineVersion                    *string
+	MasterUserPassword               *string
+	MasterUsername                   *string
+	Port                             *int64
+	ScalingConfiguration             *ScalingConfiguration
+	ServerlessV2ScalingConfiguration *ServerlessV2ScalingConfiguration
+	SnapshotIdentifier               *string
+	StorageEncrypted                 *bool
+	Tags                             []*Tag
+	VpcSecurityGroupIds              []*string
 }
 
 type ScalingConfiguration struct {
@@ -76,6 +77,11 @@ type ScalingConfiguration struct {
 	MinCapacity           *int64
 	SecondsUntilAutoPause *int64
 	TimeoutAction         *string
+}
+
+type ServerlessV2ScalingConfiguration struct {
+	MaxCapacity *float64
+	MinCapacity *float64
 }
 
 type Tag struct {


### PR DESCRIPTION
- Add support for RDS Serverless V2 (V1 is EOL as of December 31, 2024)