### PR TITLE
Add required cluster snapshot permissions

### DIFF
--- a/actions/databases.go
+++ b/actions/databases.go
@@ -309,7 +309,7 @@ func (s *server) DatabasesDelete(c buffalo.Context) error {
 	
 	actions := []string{"rds:DescribeDBInstances", "rds:DeleteDBInstance", "rds:DeleteDBCluster"}
 	if snapshot {
-		actions = append(actions, "rds:CreateDBClusterSnapshot", "rds:CreateDBSnapshot")
+		actions = append(actions, "rds:CreateDBClusterSnapshot", "rds:CreateDBSnapshot", "rds:AddTagsToResource")
 	}
 	policy, err := generatePolicy(actions...)
 	if err != nil {

--- a/actions/databases.go
+++ b/actions/databases.go
@@ -306,7 +306,12 @@ func (s *server) DatabasesDelete(c buffalo.Context) error {
 	accountId := s.mapAccountNumber(c.Param("account"))
 
 	role := fmt.Sprintf("arn:aws:iam::%s:role/%s", accountId, s.session.RoleName)
-	policy, err := generatePolicy("rds:DescribeDBInstances", "rds:DeleteDBInstance", "rds:DeleteDBCluster")
+	
+	actions := []string{"rds:DescribeDBInstances", "rds:DeleteDBInstance", "rds:DeleteDBCluster"}
+	if snapshot {
+		actions = append(actions, "rds:CreateDBClusterSnapshot", "rds:CreateDBSnapshot")
+	}
+	policy, err := generatePolicy(actions...)
 	if err != nil {
 		return handleError(c, err)
 	}


### PR DESCRIPTION
## Summary

This PR fixes critical permission issues in the RDS database deletion workflow that were causing 403 AccessDenied errors when creating final snapshots during database deletion.

### Root Cause Analysis

The error occurred because AWS RDS automatically copies tags from the source database/cluster to final snapshots created during deletion. This process requires the `rds:AddTagsToResource` permission, which was missing from the IAM policy generated for database deletion operations.

**Error encountered:**
```
User: arn:aws:sts::846761448161:assumed-role/SpinupXAManagementRoleTst/spinup-sstst-ec2-api-c705f34c-43fa-4082-ab81-d837296b8c2f is not authorized to perform: rds:AddTagsToResource on resource: arn:aws:rds:us-east-1:846761448161:cluster-snapshot:final-spinbt2l-db00000a because no session policy allows the rds:AddTagsToResource action
```

### Changes Made

#### Commit 1: `4e20884` - Add required cluster snapshot permissions
- **Problem**: The database deletion handler only included basic deletion permissions (`rds:DescribeDBInstances`, `rds:DeleteDBInstance`, `rds:DeleteDBCluster`)
- **Solution**: Enhanced the permission logic to conditionally include snapshot creation permissions when `snapshot=true` parameter is passed
- **Changes**: 
  - Added dynamic permission array construction
  - Added `rds:CreateDBClusterSnapshot` and `rds:CreateDBSnapshot` permissions for snapshot creation
  - Refactored hardcoded permission list to use a conditional approach

#### Commit 2: `5b9f449` - Fix AddTagsToResource error  
- **Problem**: Even with snapshot creation permissions, deletion still failed due to missing tag copying permissions
- **Root Cause**: When RDS creates final snapshots (named `final-<db-identifier>`), it automatically copies all tags from the source database/cluster to the snapshot, requiring `rds:AddTagsToResource` permission
- **Solution**: Added `rds:AddTagsToResource` to the conditional permissions when snapshots are being created
- **Technical Details**: 
  - This occurs in the orchestration layer at `orchestration.go:569`, `orchestration.go:593`, and `orchestration.go:618`
  - AWS uses `CopyTagsToSnapshot: true` by default in deletion operations
  - The permission is required on the cluster snapshot resource ARN

### Impact

- ✅ **Fixed**: Database deletion with `snapshot=true` parameter now works without permission errors
- ✅ **Maintained**: Existing functionality for deletion without snapshots remains unchanged  
- ✅ **Security**: Permissions are still scoped appropriately - `rds:AddTagsToResource` is only granted when snapshots are actually being created
- ✅ **Backward Compatible**: No breaking changes to API contracts or existing workflows

### Testing

This fix addresses the specific error scenario where:
1. Database deletion is requested with `snapshot=true`
2. RDS attempts to create a final snapshot with name pattern `final-<identifier>`
3. RDS automatically copies tags from source to snapshot
4. Operation previously failed due to missing `rds:AddTagsToResource` permission
5. Operation now succeeds with proper permissions

🤖 Generated with [Claude Code](https://claude.ai/code)